### PR TITLE
Refactor DocumentsController.cs to remove NotImplementedException and…

### DIFF
--- a/src/CleanArchitecture.UI.Web/Controllers/DocumentsController.cs
+++ b/src/CleanArchitecture.UI.Web/Controllers/DocumentsController.cs
@@ -51,7 +51,7 @@ namespace CleanArchitecture.UI.Web.Controllers
             return View(document);
         }
 
-        public async Task<IActionResult> Edit(Guid id)
+        public Task<IActionResult> Edit(Guid id)
         {
             throw new NotImplementedException();
         }

--- a/src/CleanArchitecture.WebAPI/Controllers/DocumentsController.cs
+++ b/src/CleanArchitecture.WebAPI/Controllers/DocumentsController.cs
@@ -7,6 +7,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace CleanArchitecture.WebAPI.Controllers
 {
+    /// <summary>
+    /// Controller for managing documents.
+    /// </summary>
     [Route("api/[controller]")]
     [ApiController]
     public class DocumentsController : ControllerBase
@@ -14,13 +17,18 @@ namespace CleanArchitecture.WebAPI.Controllers
         private readonly ILogger<DocumentsController> _logger;
         private readonly IMediator _mediator;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentsController"/> class.
+        /// </summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="mediator">The mediator instance.</param>
         public DocumentsController(ILogger<DocumentsController> logger, IMediator mediator)
         {
             _logger = logger;
             _mediator = mediator;
         }
 
-        // GET: api/<DocumentsController>
+        
         [HttpGet]
         public async Task<IEnumerable<DocumentModel>> Get()
         {
@@ -31,15 +39,27 @@ namespace CleanArchitecture.WebAPI.Controllers
             return documents;
         }
 
-        // GET api/<DocumentsController>/5
+        
+        /// <summary>
+        /// Get a document by its ID.
+        /// </summary>
+        /// <param name="id">The ID of the document.</param>
+        /// <returns>The document.</returns>
         [HttpGet("{id}")]
-        public async Task<DocumentModel> Get(Guid id)
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<DocumentModel>> Get(Guid id)
         {
             var result = await _mediator.Send(new GetPublishedDocumentQuery(id));
-
+        
+            if (result == null)
+            {
+                return NotFound();
+            }
+        
             var document = new DocumentModel(result);
-
-            return document;
+        
+            return Ok(document);
         }
     }
 }

--- a/src/CleanArchitecture.WebAPI/Controllers/DocumentsControllerTests.cs
+++ b/src/CleanArchitecture.WebAPI/Controllers/DocumentsControllerTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CleanArchitecture.Application.Documents;
+using CleanArchitecture.WebAPI.Controllers;
+using CleanArchitecture.WebAPI.Models;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace CleanArchitecture.WebAPI.Controllers.Tests
+{
+    public class DocumentsControllerTest
+    {
+        private readonly Mock<ILogger<DocumentsController>> _loggerMock;
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly DocumentsController _controller;
+
+        public DocumentsControllerTest()
+        {
+            _loggerMock = new Mock<ILogger<DocumentsController>>();
+            _mediatorMock = new Mock<IMediator>();
+            _controller = new DocumentsController(_loggerMock.Object, _mediatorMock.Object);
+        }
+
+        [Fact]
+        public async Task Get_ShouldReturnDocuments()
+        {
+            // Arrange
+            var documents = new List<DocumentDto>
+            {
+                new DocumentDto { Id = Guid.NewGuid(), Title = "Document 1" },
+                new DocumentDto { Id = Guid.NewGuid(), Title = "Document 2" }
+            };
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ListPublishedDocumentsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(documents);
+
+            // Act
+            var result = await _controller.Get();
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().HaveCount(2);
+            result.First().Title.Should().Be("Document 1");
+        }
+
+        [Fact]
+        public async Task Get_ById_ShouldReturnDocument_WhenDocumentExists()
+        {
+            // Arrange
+            var documentId = Guid.NewGuid();
+            var document = new DocumentDto { Id = documentId, Title = "Document 1" };
+            _mediatorMock.Setup(m => m.Send(It.IsAny<GetPublishedDocumentQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(document);
+
+            // Act
+            var result = await _controller.Get(documentId);
+
+            // Assert
+            result.Result.Should().BeOfType<OkObjectResult>();
+            var okResult = result.Result as OkObjectResult;
+            okResult.Value.Should().BeOfType<DocumentModel>();
+            var documentModel = okResult.Value as DocumentModel;
+            documentModel.Title.Should().Be("Document 1");
+        }
+
+        [Fact]
+        public async Task Get_ById_ShouldReturnNotFound_WhenDocumentDoesNotExist()
+        {
+            // Arrange
+            var documentId = Guid.NewGuid();
+            _mediatorMock.Setup(m => m.Send(It.IsAny<GetPublishedDocumentQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DocumentDto)null);
+
+            // Act
+            var result = await _controller.Get(documentId);
+
+            // Assert
+            result.Result.Should().BeOfType<NotFoundResult>();
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `DocumentsController` in both the web and API projects, as well as the addition of unit tests for the API controller. The most important changes include adding XML documentation comments, improving the `Get` method to handle not found cases, and adding unit tests for the `DocumentsController`.

Enhancements to `DocumentsController`:

* [`src/CleanArchitecture.WebAPI/Controllers/DocumentsController.cs`](diffhunk://#diff-e72a9366c89dde114a9980756f427fdd3540300ca72f7a1578c0a750db582ea9R10-R31): Added XML documentation comments for the controller and its methods, and improved the `Get` method to return `NotFound` when a document is not found. [[1]](diffhunk://#diff-e72a9366c89dde114a9980756f427fdd3540300ca72f7a1578c0a750db582ea9R10-R31) [[2]](diffhunk://#diff-e72a9366c89dde114a9980756f427fdd3540300ca72f7a1578c0a750db582ea9L34-R62)

Refactoring:

* [`src/CleanArchitecture.UI.Web/Controllers/DocumentsController.cs`](diffhunk://#diff-f87bcecb8f314aa8e548179aae8c48a14837f4526fd9a5008b88d9e34bdddff3L54-R54): Changed the `Edit` method to be synchronous since it throws a `NotImplementedException`.

Unit tests:

* [`src/CleanArchitecture.WebAPI/Controllers/DocumentsControllerTests.cs`](diffhunk://#diff-671c592c37681fd00163de56439432ca5fe5f0f2363619b3dcbb63967c5d0fadR1-R88): Added unit tests for the `DocumentsController` to verify the behavior of the `Get` methods, including cases where documents are found and not found.